### PR TITLE
Set accessor to return default settings when none is present

### DIFF
--- a/src/Traits/HasSettings.php
+++ b/src/Traits/HasSettings.php
@@ -16,6 +16,22 @@ trait HasSettings
         return [];
     }
 
+    /**
+     * Accessor to set default settings when one is
+     * set in model property
+     *
+     * @param $value
+     * @return array
+     */
+    public function getSettingsAttribute($value)
+    {
+        if (is_array($this->defaultSettings) && $this->defaultSettings) {
+            return $value ? array_merge(json_decode($value, true), $this->defaultSettings) : $this->defaultSettings;
+        }
+
+        return $value;
+    }
+
     abstract public function getSettingsValue(): array;
 
     abstract public function settings(): AbstractSettingsManager;

--- a/src/Traits/HasSettings.php
+++ b/src/Traits/HasSettings.php
@@ -23,7 +23,7 @@ trait HasSettings
      * @param $value
      * @return array
      */
-    public function getSettingsAttribute($value): string
+    public function getSettingsAttribute($value): array
     {
         if (is_array($this->defaultSettings) && ! empty($this->defaultSettings)) {
             return $value ? array_merge(json_decode($value, true), $this->defaultSettings) : $this->defaultSettings;

--- a/src/Traits/HasSettings.php
+++ b/src/Traits/HasSettings.php
@@ -23,9 +23,9 @@ trait HasSettings
      * @param $value
      * @return array
      */
-    public function getSettingsAttribute($value)
+    public function getSettingsAttribute($value): string
     {
-        if (is_array($this->defaultSettings) && $this->defaultSettings) {
+        if (is_array($this->defaultSettings) && ! empty($this->defaultSettings)) {
             return $value ? array_merge(json_decode($value, true), $this->defaultSettings) : $this->defaultSettings;
         }
 


### PR DESCRIPTION
This PR helps to return `defaultSettings` when a model has no setting set yet.