### PR TITLE
getKey() instead of hardcoded id issue #36

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `glorand/laravel-model-settings` will be documented in this file
 
+## 3.5.2 - 2019-12-05
+### Fix
+- https://github.com/glorand/laravel-model-settings/issues/33
+
 ## 3.5.1 - 2019-11-29
 ### Fix
 - Check column settings exists directly on the database table

--- a/src/Traits/HasSettingsTable.php
+++ b/src/Traits/HasSettingsTable.php
@@ -61,6 +61,8 @@ trait HasSettingsTable
 
     public function getSettingsCacheKey(): string
     {
-        return config('model_settings.settings_table_cache_prefix') . $this->id;
+        return config('model_settings.settings_table_cache_prefix') . $this->getTable() . '::' . $this->id;
     }
+    
+    abstract public function getTable();
 }

--- a/src/Traits/HasSettingsTable.php
+++ b/src/Traits/HasSettingsTable.php
@@ -61,8 +61,8 @@ trait HasSettingsTable
 
     public function getSettingsCacheKey(): string
     {
-        return config('model_settings.settings_table_cache_prefix') . $this->getTable() . '::' . $this->id;
+        return config('model_settings.settings_table_cache_prefix') . $this->getTable() . '::' . $this->getKey();
     }
-    
+
     abstract public function getTable();
 }


### PR DESCRIPTION
As the cache key is build directly by retrieving the ->id on the model, it cache doesn't work if the primary key has a different name.