### PR TITLE
FIX: HasSettingsField now adheres to $connection override on model (#62)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 All notable changes to `glorand/laravel-model-settings` will be documented in this file
 
-## 3.6.6 - 2020-08-25
-- default configs for a table in model_settings.php config file 
+## 3.6.7 - 2020-08-27
+### Fix
+- code refactor
 
+## 3.6.6 - 2020-08-25
+### Fix
+- default configs for a table in model_settings.php config file 
 
 ## 3.6.5 - 2020-05-07
 ### Fix

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
  <a title="MadeWithLaravel.com Shield" href="https://madewithlaravel.com/p/laravel-model-settings/shield-link"> <img src="https://madewithlaravel.com/storage/repo-shields/1716-shield.svg"/></a>
 </p>
 
-The package requires PHP 7.1.3+ and follows the FIG standards PSR-1, PSR-2 and PSR-4 
+The package requires PHP 7.1.3+ and follows the FIG standards PSR-1, PSR-2 and PSR-4
 to ensure a high level of interoperability between shared PHP.
 
 Bug reports, feature requests, and pull requests can be submitted by following our [Contribution Guide](CONTRIBUTING.md).
@@ -106,9 +106,12 @@ use Glorand\Model\Settings\Traits\HasSettingsField;
 class User extends Model
 {
     use HasSettingsField;
-    
+
     //define only if you select a different name from the default
-    public $settingsFieldName = 'user_settings';  
+    public $settingsFieldName = 'user_settings';
+
+    //define only if the model overrides the default connection
+    protected $connection = 'mysql';
 
 }
 ```
@@ -137,14 +140,14 @@ class User extends Model
 
 ## Default settings <a name="default_settings"></a>
 
-You can set default configs for a table in model_settings.php config file 
+You can set default configs for a table in model_settings.php config file
 
 ```php
 return [
     // start other config options
-    
+
     // end other config options
-    
+
     // defaultConfigs
     'defaultSettings' => [
         'users' => [
@@ -167,7 +170,7 @@ class User extends Model
 }
 ```
 
-> Please note that if you define settings in the model, the settings from configs will have no effect, they will just be ignored. 
+> Please note that if you define settings in the model, the settings from configs will have no effect, they will just be ignored.
 
 
 ## Usage <a name="usage"></a>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 <a href="https://packagist.org/packages/glorand/laravel-model-settings">
   <img src="https://poser.pugx.org/glorand/laravel-model-settings/downloads" alt="Total Downloads">
 </a>
-<a href="https://github.com/glorand/laravel-model-settings">
+<a href="https://github.com/glorand/laravel-model-settings/actions">
     <img src="https://github.com/glorand/laravel-model-settings/workflows/Test/badge.svg?branch=master">
 </a>
  <a href="https://travis-ci.com/glorand/laravel-model-settings">

--- a/src/Traits/HasSettingsField.php
+++ b/src/Traits/HasSettingsField.php
@@ -75,6 +75,14 @@ trait HasSettingsField
     }
 
     /**
+     * @return string
+     */
+    public function getConnectionName(): string
+    {
+        return $this->connection ?? config('database.default');
+    }
+
+    /**
      * @return bool
      */
     public function isPersistSettings(): bool
@@ -100,7 +108,7 @@ trait HasSettingsField
             config('model_settings.settings_table_cache_prefix') . '::has_field',
             now()->addDays(1),
             function () {
-                return Schema::hasColumn($this->getTable(), $this->getSettingsFieldName());
+                return Schema::connection($this->getConnectionName())->hasColumn($this->getTable(), $this->getSettingsFieldName());
             }
         );
     }

--- a/tests/TableSettingsManagerTest.php
+++ b/tests/TableSettingsManagerTest.php
@@ -75,7 +75,8 @@ class TableSettingsManagerTest extends TestCase
         $this->model->defaultSettings = $this->defaultSettingsTestArray;
         $this->assertEquals(
             $this->defaultSettingsTestArray,
-            $this->model->settings()->all());
+            $this->model->settings()->all()
+        );
 
         $this->model->settings()->apply($this->testArray);
         $this->assertEquals(


### PR DESCRIPTION
Modified the HasSettingsField.php to allow for reading the model's connection value (default or otherwise) as proposed on issue #62 
Updated readme.md to document change