### PR TITLE
Setup connection of the model in HasSettingsTableTrait

### DIFF
--- a/src/Managers/TableSettingsManager.php
+++ b/src/Managers/TableSettingsManager.php
@@ -27,6 +27,7 @@ class TableSettingsManager extends AbstractSettingsManager
         } else {
             if (!$modelSettings) {
                 $modelSettings = new ModelSettings();
+                $modelSettings->setConnection($this->model->getConnectionName());
                 $modelSettings->model()->associate($this->model);
             }
             $modelSettings->settings = $settings;


### PR DESCRIPTION
As I proposed -- add the ability to use connection of the model in HasSettingsTableTrait (https://github.com/glorand/laravel-model-settings/issues/74)

In this case we need it **only** if we don't have morphs (cause if we have, it's already needed connection)
But If we don't -- new model settings try to take MAIN connection, so we need to setup the one, which model use

Any question or changes please let me know

closes https://github.com/glorand/laravel-model-settings/issues/74