### PR TITLE
UPDATE: Reuse validated settings

### DIFF
--- a/src/Managers/AbstractSettingsManager.php
+++ b/src/Managers/AbstractSettingsManager.php
@@ -233,9 +233,10 @@ abstract class AbstractSettingsManager implements SettingsManagerContract
     /**
      * @param  array  $settings
      * @throws \Illuminate\Validation\ValidationException
+     * @return array
      */
-    protected function validate(array $settings)
+    protected function validate(array $settings): array
     {
-        Validator::make(Arr::wrap($settings), Arr::wrap($this->model->getRules()))->validate();
+        return Validator::make(Arr::wrap($settings), Arr::wrap($this->model->getRules()))->validate();
     }
 }

--- a/src/Managers/FieldSettingsManager.php
+++ b/src/Managers/FieldSettingsManager.php
@@ -17,7 +17,7 @@ class FieldSettingsManager extends AbstractSettingsManager
      */
     public function apply(array $settings = []): SettingsManagerContract
     {
-        $this->validate($settings);
+        $settings = $this->validate($settings);
 
         $this->model->{$this->model->getSettingsFieldName()} = json_encode($settings);
         if ($this->model->isPersistSettings()) {

--- a/src/Managers/RedisSettingsManager.php
+++ b/src/Managers/RedisSettingsManager.php
@@ -14,7 +14,7 @@ class RedisSettingsManager extends AbstractSettingsManager
 {
     public function apply(array $settings = []): SettingsManagerContract
     {
-        $this->validate($settings);
+        $settings = $this->validate($settings);
 
         Redis::set($this->model->cacheKey(), json_encode($settings));
 

--- a/src/Managers/TableSettingsManager.php
+++ b/src/Managers/TableSettingsManager.php
@@ -20,7 +20,7 @@ class TableSettingsManager extends AbstractSettingsManager
      */
     public function apply(array $settings = []): SettingsManagerContract
     {
-        $this->validate($settings);
+        $settings = $this->validate($settings);
 
         $modelSettings = $this->model->modelSettings()->first();
         if (!count($settings)) {


### PR DESCRIPTION
Currently validated settings are discarded, and that's mostly OK, but sometimes it's not.

My case comes from using [Excluding Unvalidated Array Keys](https://laravel.com/docs/8.x/validation#excluding-unvalidated-array-keys).

It's possible to call validation for settings before they are set - but that kinda defeats the purpose of using a package :smile: 