### PR TITLE
Support Laravel 10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,12 +13,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.1, 8.0]
-        laravel: [9.*]
+        php: [8.1]
+        laravel: [10.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 9.*
-            testbench: 7.*
+          - laravel: 10.*
+            testbench: 8.*
 
     name: P ${{ matrix.php }} - L ${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/composer.json
+++ b/composer.json
@@ -17,18 +17,18 @@
         "settings"
     ],
     "require": {
-        "php": "^8.0",
-        "illuminate/config": "^9.0",
-        "illuminate/database": "^9.0",
-        "illuminate/support": "^9.0",
-        "illuminate/console": "^9.0",
-        "illuminate/filesystem": "^9.0",
-        "illuminate/cache": "^9.0",
+        "php": "^8.1",
+        "illuminate/config": "^10.0",
+        "illuminate/database": "^10.0",
+        "illuminate/support": "^10.0",
+        "illuminate/console": "^10.0",
+        "illuminate/filesystem": "^10.0",
+        "illuminate/cache": "^10.0",
         "ext-json": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0|^9.0",
-        "orchestra/testbench": "^7.0",
+        "orchestra/testbench": "^8.0",
         "friendsofphp/php-cs-fixer": "^3.6",
         "josiasmontag/laravel-redis-mock": "^1.2"
     },


### PR DESCRIPTION
Laravel 10 has min. PHP version supported = 8.1 so this update will drop support of PHP 8.0 and Laravel 9. 
If you consider we also need to support Laravel 9 simultaneously (which will receive bugfixes due August 8th, 2023) - feel free to update this PR. 

