### PR TITLE
Fix "Segmentation fault" for model inheritance

### DIFF
--- a/src/Traits/HasSettings.php
+++ b/src/Traits/HasSettings.php
@@ -40,7 +40,7 @@ trait HasSettings
             return $this->settings();
         }
 
-        return call_user_func(get_parent_class($this) . '::__call', $name, $args);
+        return call_user_func(parent::class . '::__call', $name, $args);
     }
 
     abstract public function getSettingsValue(): array;

--- a/tests/Models/UsersWithParentModelWithField.php
+++ b/tests/Models/UsersWithParentModelWithField.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Glorand\Model\Settings\Tests\Models;
+
+class UsersWithParentModelWithField extends UserWithTextField {
+
+    protected $table = 'users_with_field';
+
+    protected $fillable = ['id', 'name'];
+}

--- a/tests/Models/UsersWithParentModelWithField.php
+++ b/tests/Models/UsersWithParentModelWithField.php
@@ -2,8 +2,8 @@
 
 namespace Glorand\Model\Settings\Tests\Models;
 
-class UsersWithParentModelWithField extends UserWithTextField {
-
+class UsersWithParentModelWithField extends UserWithTextField
+{
     protected $table = 'users_with_field';
 
     protected $fillable = ['id', 'name'];

--- a/tests/ParentChildSettingsTest.php
+++ b/tests/ParentChildSettingsTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Glorand\Model\Settings\Tests;
+
+use Glorand\Model\Settings\Tests\Models\UsersWithParentModelWithField;
+use Glorand\Model\Settings\Tests\Models\UserWithField as User;
+
+class ParentChildSettingsTest extends TestCase {
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->model = UsersWithParentModelWithField::first();
+    }
+
+    public function testSettingsForChild() {
+        $testArray = ['a' => 'b'];
+        $this->model->settings = $testArray;
+        $this->model->save();
+        $this->assertEquals($this->model->settings()->all(), $testArray);
+    }
+}

--- a/tests/ParentChildSettingsTest.php
+++ b/tests/ParentChildSettingsTest.php
@@ -5,15 +5,16 @@ namespace Glorand\Model\Settings\Tests;
 use Glorand\Model\Settings\Tests\Models\UsersWithParentModelWithField;
 use Glorand\Model\Settings\Tests\Models\UserWithField as User;
 
-class ParentChildSettingsTest extends TestCase {
-
+class ParentChildSettingsTest extends TestCase
+{
     public function setUp(): void
     {
         parent::setUp();
         $this->model = UsersWithParentModelWithField::first();
     }
 
-    public function testSettingsForChild() {
+    public function testSettingsForChild()
+    {
         $testArray = ['a' => 'b'];
         $this->model->settings = $testArray;
         $this->model->save();


### PR DESCRIPTION
When a class extends the Model class that uses any of the settings traits, the instance based implementation of invoking __call causes an infinite loop resulting in a segmentation fault.

