### PR TITLE
[Proposal] Removed Model::getConnectionName() override

### DIFF
--- a/src/Managers/TableSettingsManager.php
+++ b/src/Managers/TableSettingsManager.php
@@ -30,7 +30,7 @@ class TableSettingsManager extends AbstractSettingsManager
         } else {
             if (!$modelSettings) {
                 $modelSettings = new ModelSettings();
-                $modelSettings->setConnection($this->model->getConnectionName());
+                $modelSettings->setConnection($this->model->getConnectionName() ?? config('database.default'));
                 $modelSettings->model()->associate($this->model);
             }
             $modelSettings->settings = $settings;

--- a/src/Traits/HasSettingsField.php
+++ b/src/Traits/HasSettingsField.php
@@ -76,14 +76,6 @@ trait HasSettingsField
     }
 
     /**
-     * @return string
-     */
-    public function getConnectionName(): string
-    {
-        return $this->connection ?? config('database.default');
-    }
-
-    /**
      * @return bool
      */
     public function isPersistSettings(): bool
@@ -109,7 +101,7 @@ trait HasSettingsField
             config('model_settings.settings_table_cache_prefix') . '::has_field',
             now()->addDays(1),
             function () {
-                return Schema::connection($this->getConnectionName())
+                return Schema::connection($this->getConnectionName() ?? config('database.default'))
                     ->hasColumn(
                         $this->getTable(),
                         $this->getSettingsFieldName()


### PR DESCRIPTION
This is a great package, but it overrides `Model::getConnectionName()`, which proves to be a problem.  We already have simple traits that do something similar and we can't have both.

This solution moves the fallback call to `config()` (which one could argue might not be necessary) to the two instances where `getConnectionName()` is called.

Alternatives:

- Change `getConnectionName()` to `getLaravelModelSettingsConnectionName()`, which, in turn, calls `getConnectionName()` and handles the fallback.
- Don't worry about the fallback.  I **think** that `Model` will eventually fall back to the default connection.  (See `Illuminate\Database\ConnectionResolver`.)
- ...?

Let me know if you have questions/concerns, and thanks for the great work thus far.  🤓 