### PR TITLE
[Proposal] Rename HasSettings::getRules to HasSettings::getSettingsRules

### DIFF
--- a/src/Managers/AbstractSettingsManager.php
+++ b/src/Managers/AbstractSettingsManager.php
@@ -236,6 +236,6 @@ abstract class AbstractSettingsManager implements SettingsManagerContract
      */
     protected function validate(array $settings)
     {
-        Validator::make(Arr::wrap($settings), Arr::wrap($this->model->getRules()))->validate();
+        Validator::make(Arr::wrap($settings), Arr::wrap($this->model->getSettingsRules()))->validate();
     }
 }

--- a/src/Traits/HasSettings.php
+++ b/src/Traits/HasSettings.php
@@ -12,7 +12,7 @@ use Illuminate\Support\Arr;
  */
 trait HasSettings
 {
-    public function getRules(): array
+    public function getSettingsRules(): array
     {
         if (property_exists($this, 'settingsRules') && is_array($this->settingsRules)) {
             return $this->settingsRules;

--- a/src/Traits/HasSettings.php
+++ b/src/Traits/HasSettings.php
@@ -12,6 +12,16 @@ use Illuminate\Support\Arr;
  */
 trait HasSettings
 {
+    /**
+     * @deprecated Use getSettingsValue() instead
+     * Will be removed in the next major version
+     *
+     * @return array
+     */
+    public function getRules(): array
+    {
+        return $this->getSettingsRules();
+    }
     public function getSettingsRules(): array
     {
         if (property_exists($this, 'settingsRules') && is_array($this->settingsRules)) {


### PR DESCRIPTION
The HasSettings::getRules method collides with the package [wat](https://github.com/dwightwatson/validating). However, since the method here refers more to the settings than to the usual name for the validation rules, I suggest renaming the method.